### PR TITLE
add static authelia conf (for authelia auth without an upstream)

### DIFF
--- a/templates/authelia-static.conf
+++ b/templates/authelia-static.conf
@@ -25,7 +25,7 @@ server {
         # Hide authelia cookie from upstream to prevent possible session stealing attack.
         # see https://github.com/clems4ever/authelia/issues/178
         set $new_cookie $http_cookie;
-        if ($http_cookie ~ "(.*)(?:^|;)\s*connect\.sid=[^;]+(.*)") {
+        if ($http_cookie ~ "(.*)(?:^|;)\s*authelia_session=[^;]+(.*)") {
             set $new_cookie $1$2;
         }
         proxy_set_header Cookie $new_cookie;
@@ -48,14 +48,11 @@ server {
             proxy_pass {{item.authelia_internal_url}}api/verify;
 
             # low TTL cache -- allowing concurrent requests to be authorised with a single request
-            # TODO: set authelia session cookie name and use that instead.
-            # Using $http_cookie means the cache may get invalidated unexpectedly
-            # but it's safe because $http_cookie certainly contains the authelia
-            # session cookie. Besides, for a group of requests cookies are
-            # unlikely to change anyway.
-			proxy_cache auth_cache;
-			proxy_cache_valid 200 1m;
-			proxy_cache_key "$scheme$proxy_host$realip_remote_addr$http_cookie";
+            # cache must be served to the same session only -- this is
+            # guaranteed by including the authelia_session cookie.
+            proxy_cache auth_cache;
+            proxy_cache_valid 200 1m;
+            proxy_cache_key "$scheme$proxy_host$realip_remote_addr$cookie_authelia_session";
 
         }
 

--- a/templates/authelia-static.conf
+++ b/templates/authelia-static.conf
@@ -1,0 +1,64 @@
+# trimmed down version of `authelia.conf` with no built-in upstream
+# proxying. requests require auth by default, unless "auth_request off" is
+# explicitly set somewhere.
+server {
+    server_name {{item.domain}};
+
+    {% include 'sslcrt.conf' %}
+
+    include server_defaults;
+
+
+    location / {
+        auth_request /auth_verify;
+        auth_request_set $user $upstream_http_remote_user;
+        auth_request_set $groups $upstream_http_remote_groups;
+        set $target_url $scheme://$http_host$request_uri;
+
+        error_page 401 =302 {{item.authelia_external_url}}#/?rd=$target_url;
+        error_page 403 /_errors/denied.html;
+        error_page 404 /_errors/notfound.html;
+        error_page 400 500 501 503 /_errors/error.html;
+        error_page 502 504 /_errors/offline.html;
+        error_page 413 /_errors/ratelimit.html;
+
+        # Hide authelia cookie from upstream to prevent possible session stealing attack.
+        # see https://github.com/clems4ever/authelia/issues/178
+        set $new_cookie $http_cookie;
+        if ($http_cookie ~ "(.*)(?:^|;)\s*connect\.sid=[^;]+(.*)") {
+            set $new_cookie $1$2;
+        }
+        proxy_set_header Cookie $new_cookie;
+
+        location /auth_verify {
+            internal;
+            proxy_set_header Host $http_host;
+
+            proxy_set_header X-Original-Uri $request_uri;
+            proxy_set_header X-Original-Url $scheme://$http_host$request_uri;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_intercept_errors off;
+
+            proxy_pass_request_body off;
+            proxy_set_header Content-Length "";
+
+            proxy_pass {{item.authelia_internal_url}}api/verify;
+
+            # low TTL cache -- allowing concurrent requests to be authorised with a single request
+            # TODO: set authelia session cookie name and use that instead.
+            # Using $http_cookie means the cache may get invalidated unexpectedly
+            # but it's safe because $http_cookie certainly contains the authelia
+            # session cookie. Besides, for a group of requests cookies are
+            # unlikely to change anyway.
+			proxy_cache auth_cache;
+			proxy_cache_valid 200 1m;
+			proxy_cache_key "$scheme$proxy_host$realip_remote_addr$http_cookie";
+
+        }
+
+        {{item.location_extra|default('')|indent(8)}}
+    }
+}


### PR DESCRIPTION
using `authelia-static.conf` allows authentication via authelia without stipulating that, post authentication, nginx should work as a reverse-proxy for an upstream.

Use case would be a statically-hosted site that requires authentication.
